### PR TITLE
add travis

### DIFF
--- a/src/.travis.yml
+++ b/src/.travis.yml
@@ -1,0 +1,31 @@
+ 
+language: node_js
+node_js:
+ - "8.11"
+
+branches:
+  only:
+    - master
+
+addons:
+  chrome: stable
+
+before_script:
+  - yarn global add @angular/cli
+
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
+script:
+  - ng build --prod
+
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: 4c4b37dea2340437247c9258dca8c2849768cf69
+  keep-history: true
+  local-dir: ./dist/
+  on:


### PR DESCRIPTION
Esta es una prueba en la que se creo un repositorio en GitHub, el cual esta enlazado a Travis CI para el monitoreo del Continuous Integration